### PR TITLE
[FBO-159] Use correctly mkstemp in order to close file descriptors after using it.

### DIFF
--- a/pytrustnfe/certificado.py
+++ b/pytrustnfe/certificado.py
@@ -4,6 +4,7 @@
 
 import tempfile
 from OpenSSL import crypto
+import os
 
 
 class Certificado(object):
@@ -29,15 +30,13 @@ def extract_cert_and_key_from_pfx(pfx, password):
 
 
 def save_cert_key(cert, key):
-    cert_temp = tempfile.mkstemp()[1]
-    key_temp = tempfile.mkstemp()[1]
+    fd_cert, cert_temp = tempfile.mkstemp()
+    fd_key, key_temp = tempfile.mkstemp()
 
-    arq_temp = open(cert_temp, "w")
-    arq_temp.write(cert)
-    arq_temp.close()
+    os.write(fd_cert, cert.encode())
+    os.close(fd_cert)
 
-    arq_temp = open(key_temp, "w")
-    arq_temp.write(key)
-    arq_temp.close()
+    os.write(fd_key, key.encode())
+    os.close(fd_key)
 
     return cert_temp, key_temp


### PR DESCRIPTION
During the billing, we got an error when rendering xml files was executed.
The problem was when calling `mkstemp()` on `pytrustnfe` package. There is a problem on the two lines as shown below. `tempfile.mkstemp()` returns a tuple : file descriptor and the name. However the method `save_cert_key` on `pytrustnfe` package does not close the file descriptor and if we have thousands of files will raise an error  : `IOError: [Errno 24] Too many open files: '/tmp/tmpJ6g4Ke' `

```
cert_temp = tempfile.mkstemp()[1]
key_temp = tempfile.mkstemp()[1]
```

The approach for this task, was to use correctly `mkstemp()` i.e close the file descriptor.

This PR follow the **step 1** from the https://loggidev.atlassian.net/wiki/spaces/PjFinance/pages/982156428/New+Tag+release+PytrustNFe


## Manual Test
- we tested manually and looked the variation of file descriptors in another terminal for 50k and 100k files and everything was fine.

- count number of file descriptors of a specific process: `lsof -n -p <PID> | wc -l`

## Reference
- https://loggidev.atlassian.net/wiki/spaces/PjFinance/pages/982156428/New+Tag+release+PytrustNFe