### PR TITLE
[FBO-159] bump to version 1.0.48.post2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = "1.0.48.post1"
+VERSION = "1.0.48.post2"
 
 
 setup(


### PR DESCRIPTION
During the billing, we got an error when rendering xml files was executed.
The problem was when calling `mkstemp()` on `pytrustnfe` package. There is a problem on the two lines as shown below. `tempfile.mkstemp()` returns a tuple : file descriptor and the name. However the method `save_cert_key` on `pytrustnfe` package does not close the file descriptor and if we have thousands of files will raise an error  : `IOError: [Errno 24] Too many open files: '/tmp/tmpJ6g4Ke' `

```
cert_temp = tempfile.mkstemp()[1]
key_temp = tempfile.mkstemp()[1]
```

This PR follow the **step 2** from the https://loggidev.atlassian.net/wiki/spaces/PjFinance/pages/982156428/New+Tag+release+PytrustNFe

## Related PR

- https://github.com/loggi/PyTrustNFe/pull/11

## Reference
- https://loggidev.atlassian.net/wiki/spaces/PjFinance/pages/982156428/New+Tag+release+PytrustNFe
