### PR TITLE
[INFLDP-1017] Fix setup with old dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Dependências:
 * PyXmlSec
 * lxml
 * signxml
-* suds-jurko
-* suds-jurko-requests
+* suds-community
+* suds-requests4
 * reportlab
 * Jinja2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,14 +3,14 @@ coveralls
 Jinja2
 signxml
 urllib3 >= 1.22
-suds-jurko >= 0.6
-suds-jurko-requests >= 1.1
+suds-community >= 0.7.0
+suds-requests4 >= 1.0.1
 defusedxml >= 0.4.1, < 1
 eight >= 0.3.0, < 1
 cryptography >= 1.8, < 3
 pyOpenSSL >= 16.0.0, < 18
 certifi >= 2015.11.20.1
-xmlsec >= 1.3.3
+xmlsec >= 1.3.13
 reportlab
 pytest>=4.1.1
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = "1.0.48.post2"
+VERSION = "1.0.49.dev0"
 
 
 setup(
@@ -51,13 +51,13 @@ later (LGPLv2+)",
     long_description_content_type="text/markdown",
     install_requires=[
         'urllib3',
-        'xmlsec==1.3.3',  # apt update;apt install libxmlsec1-dev pkg-config -y
+        'xmlsec==1.3.13',  # apt update;apt install libxmlsec1-dev pkg-config -y
         'Jinja2 >= 2.8',
         'pyOpenSSL >= 16.0.0, < 18',
         'signxml >= 2.4.0',
         'lxml >= 3.5.0, < 5',
-        'suds-jurko >= 0.6',
-        'suds-jurko-requests >= 1.2',
+        'suds-community',
+        'suds-requests4',
         'reportlab',
         'pytz',
         'zeep',


### PR DESCRIPTION
Poetry setup with old dependencies (suds, xmlsec) aren't working as expected. This PR updates the dependencies, such as done on the original repo ([commit](https://github.com/danimaribeiro/PyTrustNFe/commit/46a68f6a75cff1d971be19c0c290f7beb707f0ae#)) so we can avoid issues during environment setup.