### PR TITLE
fix: Setup depedencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = "1.0.49.dev0"
+VERSION = "1.0.51.dev0"
 
 
 setup(
@@ -58,7 +58,7 @@ later (LGPLv2+)",
         'lxml >= 3.5.0, < 5',
         'suds-community',
         'suds-requests4',
-        'reportlab',
+        'reportlab >= 3.5.0, < 4',
         'pytz',
         'zeep',
     ],


### PR DESCRIPTION
This pull request updates the package version and tightens the version constraint for the `reportlab` dependency in `setup.py`.

Dependency versioning updates:

* Bumped the package version from `1.0.49.dev0` to `1.0.51.dev0` to reflect the new changes.
* Updated the `reportlab` dependency to require a minimum version of 3.5.0 and a maximum version less than 4, ensuring compatibility with future releases.