### PR TITLE
Adicionar suporte para mudança de versão na consulta e cancelamento

### DIFF
--- a/pytrustnfe/nfse/paulistana/__init__.py
+++ b/pytrustnfe/nfse/paulistana/__init__.py
@@ -57,13 +57,14 @@ def _send(certificado, method, **kwargs):
         response = getattr(client.service, method)(1, xml_send)
     except suds.WebFault as e:
         return {
+            "url": base_url,
             "sent_xml": xml_send,
             "received_xml": e.fault.faultstring,
             "object": None,
         }
 
     response, obj = sanitize_response(response)
-    return {"sent_xml": xml_send, "received_xml": response, "object": obj}
+    return {"sent_xml": xml_send, "received_xml": response, "object": obj, "url": base_url}
 
 
 def envio_rps(certificado, **kwargs):

--- a/pytrustnfe/nfse/paulistana/templates/CancelamentoNFe.xml
+++ b/pytrustnfe/nfse/paulistana/templates/CancelamentoNFe.xml
@@ -1,6 +1,6 @@
 <PedidoCancelamentoNFe
     xmlns="http://www.prefeitura.sp.gov.br/nfe">
-    <Cabecalho Versao="1" xmlns="">
+    <Cabecalho Versao="{{ cancelamento.versao | default('1')}}" xmlns="">
         <CPFCNPJRemetente><CNPJ>{{ cancelamento.cnpj_remetente }}</CNPJ></CPFCNPJRemetente>
         <transacao>1</transacao>
     </Cabecalho>

--- a/pytrustnfe/nfse/paulistana/templates/ConsultaNFe.xml
+++ b/pytrustnfe/nfse/paulistana/templates/ConsultaNFe.xml
@@ -1,5 +1,5 @@
 <PedidoConsultaNFe xmlns="http://www.prefeitura.sp.gov.br/nfe">
-    <Cabecalho Versao="1" xmlns="">
+    <Cabecalho Versao="{{ consulta.versao | default('1')}}" xmlns="">
         <CPFCNPJRemetente><CNPJ>{{ consulta.cnpj_remetente }}</CNPJ></CPFCNPJRemetente>
 	</Cabecalho>
     <Detalhe xmlns="">

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = "1.0.51.dev0"
+VERSION = "1.0.52.dev0"
 
 
 setup(


### PR DESCRIPTION

<img width="423" height="78" alt="image" src="https://github.com/user-attachments/assets/5ee918d7-b1d1-4016-8144-cf868670818f" />

This pull request introduces minor improvements to the NFSe Paulistana integration, focusing on enhanced configurability and better response reporting. The main changes include making XML template versions configurable and ensuring the service response includes the request URL for easier debugging.

Template configurability:

* Updated `CancelamentoNFe.xml` and `ConsultaNFe.xml` templates so the `<Cabecalho>` version is now configurable via Jinja variables, defaulting to `"1"` if not provided. This allows greater flexibility for future version changes. [[1]](diffhunk://#diff-7d1d4d8b8baedf73fc6f6ca6beca771098f0e51194da951278bc91fa10c46318L3-R3) [[2]](diffhunk://#diff-036aa2392b3c6777b11912c5bc12e7d0e87359e917434dcd170c4162097f0710L2-R2)

Service response enhancement:

* Modified the `_send` function in `pytrustnfe/nfse/paulistana/__init__.py` to include the `base_url` in both success and error responses, aiding debugging and traceability.

Version bump:

* Updated the package version in `setup.py` from `1.0.51.dev0` to `1.0.52.dev0` to reflect these changes.