### PR TITLE
Changing webservice schema version

### DIFF
--- a/pytrustnfe/nfse/paulistana/__init__.py
+++ b/pytrustnfe/nfse/paulistana/__init__.py
@@ -54,7 +54,8 @@ def _send(certificado, method, **kwargs):
     xml_send = signer.assina_xml(xml_send, "")
 
     try:
-        response = getattr(client.service, method)(1, xml_send)
+        schema_version = _get_schema_version(method, kwargs)
+        response = getattr(client.service, method)(schema_version, xml_send)
     except suds.WebFault as e:
         return {
             "url": base_url,
@@ -66,6 +67,19 @@ def _send(certificado, method, **kwargs):
     response, obj = sanitize_response(response)
     return {"sent_xml": xml_send, "received_xml": response, "object": obj, "url": base_url}
 
+
+def _get_schema_version(method, kwargs):
+    method_to_attribute_mapper = {
+        "ConsultaNFe": "consulta",
+        "CancelamentoNFe": "cancelamento",
+        "EnvioLoteRPS": "nfse",
+        "TesteEnvioLoteRPS": "nfse",
+    }
+
+    attribute = getattr(method_to_attribute_mapper, method, '')
+    schema_version = getattr(kwargs, attribute, '1')
+
+    return schema_version
 
 def envio_rps(certificado, **kwargs):
     return _send(certificado, "EnvioRPS", **kwargs)

--- a/pytrustnfe/nfse/paulistana/__init__.py
+++ b/pytrustnfe/nfse/paulistana/__init__.py
@@ -69,15 +69,16 @@ def _send(certificado, method, **kwargs):
 
 
 def _get_schema_version(method, kwargs):
-    method_to_attribute_mapper = {
+    method_to_node_mapper = {
         "ConsultaNFe": "consulta",
         "CancelamentoNFe": "cancelamento",
         "EnvioLoteRPS": "nfse",
         "TesteEnvioLoteRPS": "nfse",
     }
 
-    attribute = method_to_attribute_mapper.get(method, '')
-    schema_version = getattr(kwargs, attribute, '1')
+    node_name = method_to_node_mapper.get(method, '')
+    node = kwargs.get(node_name, {})
+    schema_version = node.get('versao', '1')
 
     return schema_version
 

--- a/pytrustnfe/nfse/paulistana/__init__.py
+++ b/pytrustnfe/nfse/paulistana/__init__.py
@@ -76,7 +76,7 @@ def _get_schema_version(method, kwargs):
         "TesteEnvioLoteRPS": "nfse",
     }
 
-    attribute = getattr(method_to_attribute_mapper, method, '')
+    attribute = method_to_attribute_mapper.get(method, '')
     schema_version = getattr(kwargs, attribute, '1')
 
     return schema_version

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = "1.0.52.dev0"
+VERSION = "1.0.53.dev0"
 
 
 setup(


### PR DESCRIPTION
This pull request introduces logic to dynamically determine the schema version when calling NFSe service methods in the `pytrustnfe` Paulistana integration. The main change is the introduction of a helper function to map methods to schema version attributes, improving flexibility in how requests are constructed.

**Dynamic schema version selection:**

* Added `_get_schema_version` helper function to map NFSe service methods to their respective schema version attributes, allowing dynamic selection of schema versions based on method and provided arguments.
* Updated the `_send` function to use the dynamic schema version when invoking service methods, replacing the previously hardcoded version.

**Version bump:**

* Incremented the package version in `setup.py` from `1.0.52.dev0` to `1.0.53.dev0`.

Tested local:
```
nfse = {'cpf_cnpj': 18277493000177,
 'data_inicio': '2026-03-18',
 'data_fim': '2026-03-18',
 'total_servicos': Decimal('10.00'),
 'valor_total_servicos': Decimal('10.00'),
 'total_deducoes': Decimal('0.00'),
 'versao': '2',
 'lista_rps': [{'assinatura': '000059871091LPD0 00000817025720260318TNN00000000000100000000000000000006302100041076932878',
   'serie': 'LPD0',
   'numero': '8170257',
   'data_emissao': '2026-03-18',
   'codigo_atividade': 6302,
   'aliquota_atividade': Decimal('0.02'),
   'valor_servico': Decimal('10.00'),
   'valor_deducao': Decimal('0.00'),
   'valor_ir': Decimal('0.00'),
   'prestador': {'inscricao_municipal': 59871091},
   'tomador': {'tipo_cpfcnpj': 1,
    'cpf_cnpj': '***********',
    'inscricao_municipal': '',
    'razao_social': 'Mateus Manetta',
    'tipo_logradouro': '',
    'logradouro': 'Rua Inacio Manuel Alvares',
    'numero': '1000',
    'bairro': 'Jardim Ester',
    'cidade': '3550308',
    'uf': 'SP',
    'cep': '05372111',
    'email': '*****@mail.com'},
   'descricao': '(teste) - Servico de cobranca dos valores dos fretes prestados pelo motofretista aos usuarios (tomadores| de servicos de transporte) da plataforma Loggi.',
   'valor_carga_tributaria': '',
   'fonte_carga_tributaria': '',
   'nbs': '123654321',
   'local_da_prestacao': '3550308',
   'ibs_cbs': {'finalidade_nfse': '0',
    'operacao_de_uso': '0',
    'codigo_indicador_da_operacao': '100501',
    'tipo_do_destinatario': '1',
    'classificacao_tributaria': '000001'}}]}


teste_envio_lote_rps(certificado, nfse=nfse)

# Return
<?xml version="1.0" encoding="UTF-8"?><RetornoEnvioLoteRPS xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.prefeitura.sp.gov.br/nfe"><Cabecalho Versao="2" xmlns=""><Sucesso>true</Sucesso><InformacoesLote><NumeroLote>0</NumeroLote><InscricaoPrestador>59871091</InscricaoPrestador><CPFCNPJRemetente><CNPJ>18277493000177</CNPJ></CPFCNPJRemetente><DataEnvioLote>2026-03-23T11:23:27</DataEnvioLote><QtdNotasProcessadas>1</QtdNotasProcessadas><TempoProcessamento>1</TempoProcessamento><ValorTotalServicos>0</ValorTotalServicos></InformacoesLote></Cabecalho></RetornoEnvioLoteRPS>

```